### PR TITLE
新增公司事件与宏观数据工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,37 @@ The server exposes the following tools through the Model Context Protocol:
 | `get_option_expiration_dates` | Get available options expiration dates |
 | `get_option_chain` | Get options chain for a specific expiration date and type (calls/puts) |
 
+### Stock Grades
+
+| Tool | Description |
+|------|-------------|
+| `get_stock_grades` | Get the latest analyst grades for a stock |
+| `get_stock_grades_historical` | Get historical analyst grades |
+| `get_stock_grades_summary` | Get a consensus summary of analyst grades |
+| `get_stock_grade_news` | Get grade-related news for a stock |
+| `get_stock_grade_latest_news` | Get the most recent analyst grade news |
+| `get_analyst_estimates` | Retrieve analyst financial estimates |
+| `get_ratings` | Get ratings snapshot or history |
+| `get_price_target_info` | Get price target summary, consensus or news |
+
+### Reference Data
+
+| Tool | Description |
+|------|-------------|
+| `lookup_identifier` | Search by symbol, name, CIK, CUSIP or ISIN |
+| `get_directory_list` | Retrieve exchange, sector and other lists |
+
+### Corporate Events
+
+| Tool | Description |
+|------|-------------|
+| `get_calendar_data` | Get dividends, earnings, IPO and split calendars |
+| `get_shares_float_info` | Retrieve float data for one or all companies |
+| `get_ma_data` | Get latest or search M&A transactions |
+| `get_executive_info` | Fetch company executives or compensation info |
+| `get_dcf_valuation` | Obtain DCF or levered DCF valuation |
+| `get_economic_data` | Retrieve treasury rates and other macro data |
+
 ## Real-World Use Cases
 
 With this MCP server, you can use Claude to:

--- a/README.zh.md
+++ b/README.zh.md
@@ -38,6 +38,37 @@
 | `get_option_expiration_dates` | 获取可用的期权到期日期 |
 | `get_option_chain` | 获取特定到期日期和类型（看涨/看跌）的期权链 |
 
+### 分析师评级
+
+| 工具 | 描述 |
+|------|-------------|
+| `get_stock_grades` | 获取股票的最新分析师评级 |
+| `get_stock_grades_historical` | 获取分析师评级历史记录 |
+| `get_stock_grades_summary` | 获取分析师评级汇总信息 |
+| `get_stock_grade_news` | 获取该股票相关的评级新闻 |
+| `get_stock_grade_latest_news` | 获取最新的分析师评级新闻 |
+| `get_analyst_estimates` | 获取分析师财务预估 |
+| `get_ratings` | 获取评级快照或历史数据 |
+| `get_price_target_info` | 获取目标价汇总、共识或相关新闻 |
+
+### 参考数据
+
+| 工具 | 描述 |
+|------|-------------|
+| `lookup_identifier` | 按股票代码、名称、CIK、CUSIP 或 ISIN 查询 |
+| `get_directory_list` | 获取交易所、行业等目录列表 |
+
+### 公司事件
+
+| 工具 | 描述 |
+|------|-------------|
+| `get_calendar_data` | 获取分红、收益、IPO、拆股等日历信息 |
+| `get_shares_float_info` | 获取单家公司或全部公司的流通股数据 |
+| `get_ma_data` | 获取最新并购交易或按名称搜索 |
+| `get_executive_info` | 获取公司高管或薪酬信息 |
+| `get_dcf_valuation` | 获取 DCF 或杠杆 DCF 估值 |
+| `get_economic_data` | 获取国债利率等宏观经济数据 |
+
 ## 实际应用场景
 
 使用此 MCP 服务器，您可以利用 Claude 进行：


### PR DESCRIPTION
## Summary
- 增加 `get_calendar_data`、`get_shares_float_info`、`get_ma_data`
- 新增 `get_executive_info`、`get_dcf_valuation`、`get_economic_data`
- 文档添加公司事件和宏观数据相关工具说明

## Testing
- `pre-commit run --files server.py README.md README.zh.md`

------
https://chatgpt.com/codex/tasks/task_b_6846b8198bf4832fadbeeb21f2372731